### PR TITLE
Correct path to check compatible

### DIFF
--- a/update-mali-driver
+++ b/update-mali-driver
@@ -185,12 +185,12 @@ die_hard_with_a_cleanup() {
 
 trap "die_hard_with_a_cleanup interrupted" INT
 
-if [ ! -f /sys/firmware/devicetree/base/compatible ]; then
+if [ ! -f /proc/device-tree/compatible ]; then
 	die_hard_with_a_cleanup "no devicetree information found"
 fi
 
 # find machine type and try to match against supported machines
-machine=`xargs --null < /sys/firmware/devicetree/base/compatible`
+machine=`xargs --null < /proc/device-tree/compatible`
 [ "$verbose" != "yes" ] || echo "this machine $machine"
 
 found=""


### PR DESCRIPTION
According to https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-firmware-ofw the correct place to look is in /proc for the device-tree information, not in /sys.
